### PR TITLE
ci: add workflow for duplicating issues to validatorctl

### DIFF
--- a/.github/workflows/issue.yaml
+++ b/.github/workflows/issue.yaml
@@ -1,0 +1,10 @@
+name: Create Issue
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  create-issue:
+    uses: validator-labs/workflows/.github/workflows/issue.yaml@main
+    secrets: inherit


### PR DESCRIPTION
## Issue

## Description
Adding a workflow to duplicate issues from the plugin repo into validatorctl. 

When a new issue is created which requires work in both the plugin and validatorctl repos, it should be labeled with `validatorctl`. A copy will be automatically made in the `validatorctl` repo, assigned to the same person, and added to the `validator` project board.