### PR TITLE
fix: metrics targetPort https -> 8443

### DIFF
--- a/chart/validator-plugin-kubescape/README.md
+++ b/chart/validator-plugin-kubescape/README.md
@@ -26,7 +26,7 @@ The following table lists the configurable parameters of the Validator-plugin-ku
 | `controllerManager.volumes` |  | `[]` |
 | `controllerManager.podLabels` |  | `{}` |
 | `kubernetesClusterDomain` |  | `"cluster.local"` |
-| `metricsService.ports` |  | `[{"name": "https", "port": 8443, "protocol": "TCP", "targetPort": "https"}]` |
+| `metricsService.ports` |  | `[{"name": "https", "port": 8443, "protocol": "TCP", "targetPort": 8443}]` |
 | `metricsService.type` |  | `"ClusterIP"` |
 
 

--- a/chart/validator-plugin-kubescape/values.yaml
+++ b/chart/validator-plugin-kubescape/values.yaml
@@ -36,5 +36,5 @@ metricsService:
   - name: https
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: 8443
   type: ClusterIP


### PR DESCRIPTION
Metrics server is exposed on port 8443. This PR updates the metrics service chart value to match this, to ensure it's accessible.
